### PR TITLE
guard transform_plain_ref against empty buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,8 +59,8 @@ function discover_loose(basepath, fs) {
       .pipe(packedrefs())
       .pipe(through(transform_packed_ref))
       .on('data', format_type(stream, 'packed-ref'))
-      .on('error', maybe_end) 
-      .on('end', maybe_end) 
+      .on('error', maybe_end)
+      .on('end', maybe_end)
   }
 
   function read_ref(relpath, type, name) {
@@ -68,8 +68,8 @@ function discover_loose(basepath, fs) {
       .pipe(accum())
       .pipe(through(transform_plain_ref))
       .on('data', format_type(stream, type, name))
-      .on('error', maybe_end) 
-      .on('end', maybe_end) 
+      .on('error', maybe_end)
+      .on('end', maybe_end)
   }
 }
 
@@ -92,7 +92,7 @@ function transform_plain_ref(buf) {
     , hash: null
     , type: null
     , name: null
-    })  
+    })
   }
 
   this.queue({

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function transform_packed_ref(packed_entry) {
 
 function transform_plain_ref(buf) {
   // "ref:" as a big endian integer
-  if(buf.readUInt32BE(0) === 0x7265663a) {
+  if(buf.length && buf.readUInt32BE(0) === 0x7265663a) {
     return this.queue({
       symbolic: true
     , ref: buf.slice(5).toString('utf8').replace(/\n$/, '')


### PR DESCRIPTION
-  fixes bugs related to unexpected empty buffers, e.g.:

```
buffer.js:635
    throw new RangeError('index out of range');
    ^

RangeError: index out of range
    at checkOffset (buffer.js:635:11)
    at Buffer.readUInt32BE (buffer.js:709:5)
    at Stream.transform_plain_ref (~/git-semver-tags/node_modules/git-load-refs/index.js:89:10)
    at Stream.stream.write (~/git-semver-tags/node_modules/through/index.js:25:11)
    at Stream.ondata (stream.js:31:26)
    at emitOne (events.js:90:13)
    at Stream.emit (events.js:182:7)
    at drain (~/git-semver-tags/node_modules/through/index.js:35:16)
    at Stream.stream.queue.stream.push (~/git-semver-tags/node_modules/through/index.js:41:5)
    at Stream.end (~/git-semver-tags/node_modules/git-load-refs/index.js:132:12)
```
-  adds simple `buf.length` check
